### PR TITLE
Support CircleCI, GitHub Actions

### DIFF
--- a/autify_mobile_cli.sh
+++ b/autify_mobile_cli.sh
@@ -71,7 +71,13 @@ main() {
   # body
   BODY=$(echo "$RESPONSE" | sed '$d')
   # set env
-  envman add --key "AUTIFY_UPLOAD_STEP_RESULT_JSON" --value "$BODY"
+  if [ -n "$BITRISE_IO" ];then
+    envman add --key "AUTIFY_UPLOAD_STEP_RESULT_JSON" --value "$BODY"
+  elif [ -n "$CIRCLECI" ];then
+    echo "export AUTIFY_UPLOAD_STEP_RESULT_JSON=$BODY" >> $BASH_ENV
+  elif [ -n "$GITHUB_ACTIONS" ];then
+    echo "AUTIFY_UPLOAD_STEP_RESULT_JSON=$BODY" >> $GITHUB_ENV
+  fi
 
   if [[ "$HTTP_STATUS" != "201" ]]; then
     error "$BODY"


### PR DESCRIPTION
envman command is only for Bitrise.

* setting Environment Variable by redirect, then variables are only available from next step.
    * CircleCI Document: https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command
    * Github Document: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

* CI specific environment variables:
    * `BITRISE_IO` https://devcenter.bitrise.io/en/references/available-environment-variables.html
    * `CIRCLECI` https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
    * `GITHUB_ACTIONS` https://docs.github.com/en/actions/learn-github-actions/environment-variables