### PR TITLE
Fix CircleCI Support

### DIFF
--- a/autify_mobile_cli.sh
+++ b/autify_mobile_cli.sh
@@ -74,7 +74,7 @@ main() {
   if [ -n "$BITRISE_IO" ];then
     envman add --key "AUTIFY_UPLOAD_STEP_RESULT_JSON" --value "$BODY"
   elif [ -n "$CIRCLECI" ];then
-    echo "export AUTIFY_UPLOAD_STEP_RESULT_JSON=$BODY" >> $BASH_ENV
+    echo "export AUTIFY_UPLOAD_STEP_RESULT_JSON='$BODY'" >> $BASH_ENV
   elif [ -n "$GITHUB_ACTIONS" ];then
     echo "AUTIFY_UPLOAD_STEP_RESULT_JSON=$BODY" >> $GITHUB_ENV
   fi


### PR DESCRIPTION
I have discovered that the value of the `AUTIFY_UPLOAD_STEP_RESULT_JSON` environment variable cannot be parsed by jq when running on CircleCI.

When I checked the value of `AUTIFY_UPLOAD_STEP_RESULT_JSON`, I found that the json double-quote was missing, as follows.

```
{id:xxxxxx}
```

What I was looking for is a value like this

```
{"id":"xxxxxx"}
```

By enclosing $BODY in single quotes when putting a value into an environment variable, the export statement changes to this when $BODY is expanded.

```
before:
export AUTIFY_UPLOAD_STEP_RESULT_JSON={"id":"xxxxxx"}
echo $AUTIFY_UPLOAD_STEP_RESULT_JSON

>> {id:xxxxxx}
```

```
after:
export AUTIFY_UPLOAD_STEP_RESULT_JSON='{"id":"xxxxxx"}'
echo $AUTIFY_UPLOAD_STEP_RESULT_JSON

>> {"id":"xxxxxx"}
```

Please confirm that this will allow us to parse with jq.